### PR TITLE
[AutoDiff] Cross-import overlay for tgmath derivatives.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -562,7 +562,7 @@ inline llvm::raw_ostream &operator<<(
 }
 
 /// Returns `true` iff differentiable programming is enabled.
-bool isDifferentiableProgrammingEnabled(SourceFile &SF);
+bool isDifferentiableProgrammingEnabled(const SourceFile &SF);
 
 /// Automatic differentiation utility namespace.
 namespace autodiff {

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -109,7 +109,7 @@ void AutoDiffConfig::print(llvm::raw_ostream &s) const {
   s << ')';
 }
 
-bool swift::isDifferentiableProgrammingEnabled(SourceFile &SF) {
+bool swift::isDifferentiableProgrammingEnabled(const SourceFile &SF) {
   auto &ctx = SF.getASTContext();
   // Return true if differentiable programming is explicitly enabled.
   if (ctx.LangOpts.EnableExperimentalDifferentiableProgramming)

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AccessScope.h"
+#include "swift/AST/AutoDiff.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -2208,8 +2209,14 @@ SPIGroupsRequest::evaluate(Evaluator &evaluator, const Decl *decl) const {
 }
 
 bool SourceFile::shouldCrossImport() const {
-  return Kind != SourceFileKind::SIL && Kind != SourceFileKind::Interface &&
-         getASTContext().LangOpts.EnableCrossImportOverlays;
+  if (Kind == SourceFileKind::SIL || Kind == SourceFileKind::Interface)
+    return false;
+  // Cross import when experimental differentiable programming is enabled. This
+  // is to enable tgmath derivatives defined in the platform differentiation
+  // overlay.
+  if (isDifferentiableProgrammingEnabled(*this))
+    return true;
+  return getASTContext().LangOpts.EnableCrossImportOverlays;
 }
 
 void ModuleDecl::clearLookupCache() {

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -106,6 +106,9 @@ endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
   add_subdirectory(Platform)
+  if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
+    add_subdirectory(PlatformDifferentiation)
+  endif()
 endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY)

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -22,19 +22,7 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
 
   GYB_SOURCES
     FloatingPointDifferentiation.swift.gyb
-    TgmathDerivatives.swift.gyb
     SIMDDifferentiation.swift.gyb
-
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-  SWIFT_MODULE_DEPENDS_LINUX Glibc
-  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
-  SWIFT_MODULE_DEPENDS_OPENBSD Glibc
-  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
-  SWIFT_MODULE_DEPENDS_HAIKU Glibc
-  SWIFT_MODULE_DEPENDS_WINDOWS CRT
 
   C_COMPILE_FLAGS
     -Dswift_Differentiation_EXPORTS

--- a/stdlib/public/PlatformDifferentiation/CMakeLists.txt
+++ b/stdlib/public/PlatformDifferentiation/CMakeLists.txt
@@ -1,0 +1,57 @@
+#===--- CMakeLists.txt - Platform differentiation library ----------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+add_swift_target_library(swift_Darwin_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+  "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
+
+  GYB_SOURCES
+    TgmathDerivatives.swift.gyb
+
+  SWIFT_MODULE_DEPENDS_OSX Darwin _Differentiation
+  SWIFT_MODULE_DEPENDS_IOS Darwin _Differentiation 
+  SWIFT_MODULE_DEPENDS_TVOS Darwin _Differentiation
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin _Differentiation
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  TARGET_SDKS ALL_APPLE_PLATFORMS FREESTANDING
+  INSTALL_IN_COMPONENT sdk-overlay)
+
+
+add_swift_target_library(swift_Glibc_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+  GYB_SOURCES
+    TgmathDerivatives.swift.gyb
+
+  SWIFT_MODULE_DEPENDS_LINUX Glibc _Differentiation
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc _Differentiation
+  SWIFT_MODULE_DEPENDS_OPENBSD Glibc _Differentiation
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc _Differentiation
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc _Differentiation
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  TARGET_SDKS ANDROID CYGWIN FREEBSD OPENBSD LINUX HAIKU
+  INSTALL_IN_COMPONENT sdk-overlay)
+
+add_swift_target_library(swift_CRT_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+  GYB_SOURCES
+    TgmathDerivatives.swift.gyb
+
+  SWIFT_MODULE_DEPENDS_WINDOWS CRT _Differentiation
+
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  TARGET_SDKS WINDOWS
+  INSTALL_IN_COMPONENT sdk-overlay)

--- a/stdlib/public/PlatformDifferentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/PlatformDifferentiation/TgmathDerivatives.swift.gyb
@@ -12,14 +12,14 @@
 // This file defines derivatives for tgmath functions.
 //===----------------------------------------------------------------------===//
 
-import Swift
+import _Differentiation
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-  import Darwin.C.tgmath
+  @_exported import Darwin.C.tgmath
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
-  import Glibc
+  @_exported import Glibc
 #elseif os(Windows)
-  import CRT
+  @_exported import CRT
 #else
 #error("Unsupported platform")
 #endif


### PR DESCRIPTION
Move tgmath derivatives to a cross-import overlay `_{Darwin|Glibc|CRT}__Differentiation`. Make `_Differentiation` no longer depend on Darwin/Glibc/CRT.

Resolves rdar://69052246.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
